### PR TITLE
docs: improve code style and documentation

### DIFF
--- a/_version.py
+++ b/_version.py
@@ -1,2 +1,4 @@
-# Labels_App/_version.py
+"""Informações de versão do aplicativo."""
+
 __version__ = "6.0"
+

--- a/main.py
+++ b/main.py
@@ -1,30 +1,43 @@
-# main.py
+"""Ponto de entrada do aplicativo de geração de etiquetas."""
+
 import os
 import sys
 from datetime import datetime
+
 from PyQt5.QtWidgets import QApplication
-from ui import EtiquetaApp
+
 from _version import __version__
+from ui import EtiquetaApp
 from utils import migrate_legacy_data
 
-def ensure_version_file():
+def ensure_version_file() -> None:
+    """Garante a criação do arquivo de versão.
+
+    Cria ou atualiza ``version.txt`` no diretório do executável quando o
+    aplicativo está congelado ou no diretório do arquivo em ambiente de
+    desenvolvimento.
+
+    Returns:
+        None
     """
-    Cria/atualiza um version.txt no diretório do executável (quando congelado)
-    ou no diretório deste arquivo (em dev).
-    """
+
     try:
         if getattr(sys, "frozen", False):
-            install_dir = os.path.dirname(sys.executable)   # caminho do .exe (PyInstaller)
+            # Caminho do executável gerado pelo PyInstaller.
+            install_dir = os.path.dirname(sys.executable)
         else:
-            install_dir = os.path.dirname(os.path.abspath(__file__))  # caminho dos .py
+            # Caminho dos arquivos .py em ambiente de desenvolvimento.
+            install_dir = os.path.dirname(os.path.abspath(__file__))
 
         path = os.path.join(install_dir, "version.txt")
-        with open(path, "w", encoding="utf-8") as f:
-            f.write(str(__version__))
+        with open(path, "w", encoding="utf-8") as arquivo:
+            arquivo.write(str(__version__))
     except Exception:
-        # não falhe a inicialização por causa disso; apenas logue
-        with open("crash_log.txt", "a", encoding="utf-8") as f:
-            f.write(f"[{datetime.now():%d/%m/%Y %H:%M:%S}] Falha ao gravar version.txt\n")
+        # Não interrompe a inicialização; apenas registra o problema.
+        with open("crash_log.txt", "a", encoding="utf-8") as log:
+            log.write(
+                f"[{datetime.now():%d/%m/%Y %H:%M:%S}] Falha ao gravar version.txt\n"
+            )
 
 if __name__ == "__main__":
     try:

--- a/persistence.py
+++ b/persistence.py
@@ -1,19 +1,26 @@
-# persistence.py
-import os
-import json
+"""Funções de persistência de dados do aplicativo."""
+
 import csv
+import json
+import os
 from datetime import datetime
+
 from utils import recurso_caminho
 
-def carregar_contagem():
-    """Lê o arquivo de contagem.json e retorna total_geral, total_mes."""
+def carregar_contagem() -> tuple[int, int]:
+    """Lê os contadores de impressão.
+
+    Returns:
+        tuple[int, int]: Total geral e total do mês atual.
+    """
+
     caminho = recurso_caminho("contagem.json")
     mes_atual = datetime.now().strftime("%m-%Y")
     contagem_total = 0
     contagem_mensal = 0
     if os.path.exists(caminho):
-        with open(caminho, "r", encoding="utf-8") as f:
-            dados = json.load(f)
+        with open(caminho, "r", encoding="utf-8") as arquivo:
+            dados = json.load(arquivo)
         if dados.get("mes_atual") == mes_atual:
             contagem_total = int(dados.get("total_geral") or 0)
             contagem_mensal = int(dados.get("total_mes") or 0)
@@ -25,8 +32,14 @@ def carregar_contagem():
         salvar_contagem(0, 0)
     return contagem_total, contagem_mensal
 
-def salvar_contagem(contagem_total, contagem_mensal):
-    """Salva os contadores em contagem.json."""
+def salvar_contagem(contagem_total: int, contagem_mensal: int) -> None:
+    """Persiste os contadores de impressão.
+
+    Args:
+        contagem_total (int): Quantidade total de etiquetas impressas.
+        contagem_mensal (int): Quantidade de etiquetas impressas no mês.
+    """
+
     caminho = recurso_caminho("contagem.json")
     os.makedirs(os.path.dirname(caminho), exist_ok=True)
     dados = {
@@ -34,38 +47,65 @@ def salvar_contagem(contagem_total, contagem_mensal):
         "total_mes": int(contagem_mensal or 0),
         "mes_atual": datetime.now().strftime("%m-%Y"),
     }
-    with open(caminho, "w", encoding="utf-8") as f:
-        json.dump(dados, f, ensure_ascii=False, indent=4)
+    with open(caminho, "w", encoding="utf-8") as arquivo:
+        json.dump(dados, arquivo, ensure_ascii=False, indent=4)
 
-def salvar_historico(saida, categoria, emissor, municipio, volumes, data_hora):
-    """Adiciona uma linha no histórico de impressões (CSV)."""
+def salvar_historico(
+    saida: str,
+    categoria: str,
+    emissor: str,
+    municipio: str,
+    volumes: int,
+    data_hora: str,
+) -> None:
+    """Adiciona registro ao histórico de impressões.
+
+    Args:
+        saida (str): Número da saída.
+        categoria (str): Categoria da etiqueta.
+        emissor (str): Nome de quem emitiu a etiqueta.
+        municipio (str): Município de destino.
+        volumes (int): Quantidade de volumes impressos.
+        data_hora (str): Data e hora da impressão.
+    """
+
     caminho = recurso_caminho("historico_impressoes.csv")
     existe = os.path.exists(caminho)
-    with open(caminho, "a", newline="", encoding="utf-8-sig") as arq:
-        w = csv.writer(arq, delimiter=";")
+    with open(caminho, "a", newline="", encoding="utf-8-sig") as arquivo:
+        writer = csv.writer(arquivo, delimiter=";")
         if not existe:
-            w.writerow(
-                ["Data e Hora", "Saída", "Categoria",
-                 "Emissor", "Município", "Volumes"]
+            writer.writerow(
+                ["Data e Hora", "Saída", "Categoria", "Emissor", "Município", "Volumes"]
             )
-        w.writerow([data_hora, saida, categoria, emissor, municipio, volumes])
+        writer.writerow([data_hora, saida, categoria, emissor, municipio, volumes])
         
-def registrar_contagem_mensal(mes, quantidade):
-    """Soma ao mês informado a quantidade de etiquetas impressas."""
+def registrar_contagem_mensal(mes: str, quantidade: int) -> None:
+    """Atualiza o total de etiquetas por mês.
+
+    Args:
+        mes (str): Mês no formato ``MM-YYYY``.
+        quantidade (int): Quantidade de etiquetas a somar.
+    """
+
     caminho = recurso_caminho("contagem_mensal.json")
     if os.path.exists(caminho):
-        with open(caminho, "r", encoding="utf-8") as f:
-            dados = json.load(f)
+        with open(caminho, "r", encoding="utf-8") as arquivo:
+            dados = json.load(arquivo)
     else:
         dados = {}
     dados[mes] = dados.get(mes, 0) + quantidade
-    with open(caminho, "w", encoding="utf-8") as f:
-        json.dump(dados, f, ensure_ascii=False, indent=2)
+    with open(caminho, "w", encoding="utf-8") as arquivo:
+        json.dump(dados, arquivo, ensure_ascii=False, indent=2)
 
-def carregar_historico_mensal():
-    """Retorna o dicionário mês:total."""
+def carregar_historico_mensal() -> dict[str, int]:
+    """Obtém os dados de impressão por mês.
+
+    Returns:
+        dict[str, int]: Mapeamento de ``mes`` para ``total`` de etiquetas.
+    """
+
     caminho = recurso_caminho("contagem_mensal.json")
     if os.path.exists(caminho):
-        with open(caminho, "r", encoding="utf-8") as f:
-            return json.load(f)
+        with open(caminho, "r", encoding="utf-8") as arquivo:
+            return json.load(arquivo)
     return {}

--- a/printing.py
+++ b/printing.py
@@ -1,21 +1,43 @@
-# printing.py
-import win32print
+"""Rotinas relacionadas à impressão das etiquetas."""
+
 from datetime import datetime
-from utils import recurso_caminho, melhorar_logo
+
+import win32print
+
+from utils import melhorar_logo, recurso_caminho
 
 LARGURA_ETIQUETA_MM = 60
 ALTURA_ETIQUETA_MM = 80
 DOTS_MM = 8  # ~203 dpi
 
 def imprimir_etiqueta(
-    saida, categoria, emissor, municipio, volumes, data_hora,
-    contagem_total=0, contagem_mensal=0,
-    inicio_indice: int = 1,           # <-- NOVO: inicia numeração em N
-    total_exibicao: int = None        # <-- NOVO: total mostrado em "X DE Y"
-):
-    """
-    Monta e envia o comando TSPL para a impressora padrão.
-    Retorna True se ok, senão gera exceção.
+    saida: str,
+    categoria: str,
+    emissor: str,
+    municipio: str,
+    volumes: int,
+    data_hora: str,
+    contagem_total: int = 0,
+    contagem_mensal: int = 0,
+    inicio_indice: int = 1,
+    total_exibicao: int | None = None,
+) -> bool:
+    """Monta e envia comandos TSPL para a impressora padrão.
+
+    Args:
+        saida (str): Número da saída.
+        categoria (str): Categoria da etiqueta.
+        emissor (str): Quem emitiu a etiqueta.
+        municipio (str): Município de destino.
+        volumes (int): Quantidade de etiquetas a imprimir.
+        data_hora (str): Data e hora formatadas da impressão.
+        contagem_total (int, optional): Total geral antes da impressão.
+        contagem_mensal (int, optional): Total do mês antes da impressão.
+        inicio_indice (int, optional): Número inicial para a sequência.
+        total_exibicao (int | None, optional): Total exibido no rodapé.
+
+    Returns:
+        bool: ``True`` se a impressão ocorrer sem erros.
     """
     # -------- prepara logo --------
     logo_path = recurso_caminho("logo.png")

--- a/ui.py
+++ b/ui.py
@@ -1,28 +1,45 @@
-# ui.py
+"""Elementos da interface gráfica do gerador de etiquetas."""
+
 import os
 import sys
 from datetime import datetime
+
+from PyQt5.QtCore import QDateTime, QTime, Qt, QTimer
+from PyQt5.QtGui import QColor, QFont, QIcon, QPalette, QPixmap
 from PyQt5.QtWidgets import (
-    QWidget, QLabel, QLineEdit, QComboBox, QSpinBox, QPushButton,
-    QVBoxLayout, QGridLayout, QHBoxLayout, QFrame, QSpacerItem,
-    QSizePolicy, QMessageBox, QInputDialog
+    QComboBox,
+    QFrame,
+    QGridLayout,
+    QHBoxLayout,
+    QInputDialog,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QSizePolicy,
+    QSpinBox,
+    QSpacerItem,
+    QVBoxLayout,
+    QWidget,
 )
-from PyQt5.QtGui import QPixmap, QFont, QPalette, QColor, QIcon
-from PyQt5.QtCore import Qt, QTimer
 
-from utils import backup_automatico
-from PyQt5.QtCore import QTime, QDateTime
-
-from utils import recurso_caminho
 from persistence import (
-    carregar_contagem, salvar_contagem, salvar_historico,
-    registrar_contagem_mensal, carregar_historico_mensal
+    carregar_contagem,
+    carregar_historico_mensal,
+    registrar_contagem_mensal,
+    salvar_contagem,
+    salvar_historico,
 )
 from printing import imprimir_etiqueta
+from utils import backup_automatico, recurso_caminho
 
 
 class EtiquetaApp(QWidget):
-    def __init__(self):
+    """Janela principal do gerador de etiquetas."""
+
+    def __init__(self) -> None:
+        """Inicializa a interface gráfica e configura a janela."""
+
         super().__init__()
         self.setWindowTitle("Gerador de Etiquetas CONIMS")
         self.setGeometry(300, 100, 800, 720)
@@ -41,7 +58,9 @@ class EtiquetaApp(QWidget):
         self._atualizar_status("🟢 Pronto")
         self._agendar_backup_diario()
 
-    def _agendar_backup_diario(self):
+    def _agendar_backup_diario(self) -> None:
+        """Agenda a execução do backup diário às 17h10."""
+
         agora = QDateTime.currentDateTime()
         fim_do_dia = QDateTime(agora.date(), QTime(17, 10, 0))
         if agora > fim_do_dia:
@@ -53,15 +72,21 @@ class EtiquetaApp(QWidget):
         self._timer_backup.timeout.connect(self._executar_backup_diario)
         self._timer_backup.start(ms_ate_backup)
 
-    def _executar_backup_diario(self):
+    def _executar_backup_diario(self) -> None:
+        """Executa o backup e reagenda a próxima execução."""
+
         backup_automatico()
         self._agendar_backup_diario()
 
-    def closeEvent(self, event):
+    def closeEvent(self, event) -> None:  # type: ignore[override]
+        """Garante um backup ao fechar a janela."""
+
         backup_automatico()
         event.accept()
 
     def _setup_ui(self):
+        """Monta todos os widgets e layouts da interface."""
+
         layout_base = QVBoxLayout(self)
         layout_base.setContentsMargins(0, 0, 0, 0)
         layout_base.addSpacerItem(QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding))
@@ -147,7 +172,9 @@ class EtiquetaApp(QWidget):
 
         layout_base.addSpacerItem(QSpacerItem(20, 40, QSizePolicy.Minimum, QSizePolicy.Expanding))
 
-    def _aplicar_tema_escuro(self):
+    def _aplicar_tema_escuro(self) -> None:
+        """Aplica esquema de cores escuro à aplicação."""
+
         p = QPalette()
         p.setColor(QPalette.Window, QColor(30, 30, 30))
         p.setColor(QPalette.WindowText, Qt.white)
@@ -157,7 +184,9 @@ class EtiquetaApp(QWidget):
         p.setColor(QPalette.ButtonText, Qt.white)
         self.setPalette(p)
 
-    def _carregar_listas(self):
+    def _carregar_listas(self) -> None:
+        """Preenche as listas de seleção com valores padrão."""
+
         self.categoria_input.addItems([
             "", "LIMPEZA, COPA, COZINHA", "DEVOLUCAO", "ORTOPEDICO", "CRE CHOPIM",
             "EXPEDIENTE", "OSTOMIA", "CURATIVOS", "LIMPEZA", "NUTRIÇAO",
@@ -180,18 +209,30 @@ class EtiquetaApp(QWidget):
             "SAUDADE DO IGUACU", "SULINA", "VITORINO",
         ])
 
-    def _limpar_campos(self):
+    def _limpar_campos(self) -> None:
+        """Restaura os campos do formulário para os valores iniciais."""
+
         self.saida_input.clear()
         for combo in (self.categoria_input, self.emissor_input, self.municipio_input):
             combo.setCurrentIndex(0)
         self.volumes_input.setValue(1)
 
-    def _atualizar_status(self, mensagem: str = "🟢 Pronto", cor: str = "white"):
+    def _atualizar_status(self, mensagem: str = "🟢 Pronto", cor: str = "white") -> None:
+        """Atualiza a mensagem de status exibida ao usuário.
+
+        Args:
+            mensagem (str, optional): Texto a ser mostrado. Padrão "🟢 Pronto".
+            cor (str, optional): Cor do texto. Padrão ``white``.
+        """
+
         self.status_label.setText(mensagem)
         self.status_label.setStyleSheet(f"color:{cor};padding:5px")
 
-    def _abrir_historico(self):
+    def _abrir_historico(self) -> None:
+        """Abre o arquivo CSV de histórico no sistema operacional."""
+
         import subprocess
+
         caminho = recurso_caminho("historico_impressoes.csv")
         if os.path.exists(caminho):
             subprocess.Popen(["start", "", caminho], shell=True)
@@ -199,6 +240,8 @@ class EtiquetaApp(QWidget):
             QMessageBox.information(self, "Histórico", "O arquivo de histórico ainda não existe.")
 
     def _imprimir_etiqueta(self):
+        """Coleta dados do formulário e solicita a impressão."""
+
         self._atualizar_status("🖨️ Imprimindo…")
         saida = str(self.saida_input.text()).strip()
         categoria = self.categoria_input.currentText()
@@ -248,7 +291,9 @@ class EtiquetaApp(QWidget):
                 )
             QMessageBox.critical(self, "Erro", str(e))
 
-    def _reimprimir_ultima(self):
+    def _reimprimir_ultima(self) -> None:
+        """Reimprime a última etiqueta gerada, se houver."""
+
         if not self.ultima_etiqueta:
             QMessageBox.information(self, "Nenhuma etiqueta", "Nenhuma etiqueta foi impressa ainda.")
             return
@@ -270,7 +315,9 @@ class EtiquetaApp(QWidget):
                 )
             QMessageBox.critical(self, "Erro", str(e))
 
-    def _reimprimir_faltantes(self):
+    def _reimprimir_faltantes(self) -> None:
+        """Reimprime apenas as etiquetas que faltaram de um lote."""
+
         if not self.ultima_etiqueta:
             QMessageBox.information(self, "Nenhuma etiqueta", "Nenhuma etiqueta foi impressa ainda.")
             return
@@ -278,11 +325,14 @@ class EtiquetaApp(QWidget):
         dados = self.ultima_etiqueta
         total = int(dados["volumes"])
 
-        # peça um número entre 1 e "total"
         faltantes, ok = QInputDialog.getInt(
-            self, "Reimprimir Faltantes",
+            self,
+            "Reimprimir Faltantes",
             f"Quantas etiquetas faltaram desse lote de {total}?",
-            1, 1, total, 1
+            1,
+            1,
+            total,
+            1,
         )
         if not ok:
             return
@@ -292,21 +342,30 @@ class EtiquetaApp(QWidget):
         try:
             from persistence import salvar_contagem, salvar_historico
 
-            # se preferir carimbar a data da reimpressão, use datetime.now() em vez de dados["data_hora"]
             imprimir_etiqueta(
-                dados["saida"], dados["categoria"], dados["emissor"],
-                dados["municipio"], faltantes, dados["data_hora"],
-                self.contagem_total, self.contagem_mensal,
-                inicio_indice=inicio, total_exibicao=total
+                dados["saida"],
+                dados["categoria"],
+                dados["emissor"],
+                dados["municipio"],
+                faltantes,
+                dados["data_hora"],
+                self.contagem_total,
+                self.contagem_mensal,
+                inicio_indice=inicio,
+                total_exibicao=total,
             )
 
-            # >>> atualiza contadores e histórico só com as faltantes <<<
+            # Atualiza contadores e histórico apenas com as faltantes
             self.contagem_total += faltantes
             self.contagem_mensal += faltantes
             salvar_contagem(self.contagem_total, self.contagem_mensal)
             salvar_historico(
-                dados["saida"], dados["categoria"], dados["emissor"], dados["municipio"],
-                faltantes, datetime.now().strftime("%d/%m/%Y %H:%M")
+                dados["saida"],
+                dados["categoria"],
+                dados["emissor"],
+                dados["municipio"],
+                faltantes,
+                datetime.now().strftime("%d/%m/%Y %H:%M"),
             )
             self._atualizar_contagem_label()
 
@@ -322,7 +381,9 @@ class EtiquetaApp(QWidget):
             QMessageBox.critical(self, "Erro", str(e))
 
 
-    def _mostrar_historico_mensal(self):
+    def _mostrar_historico_mensal(self) -> None:
+        """Exibe um resumo das etiquetas impressas por mês."""
+
         hist = carregar_historico_mensal()
         if not hist:
             QMessageBox.information(self, "Histórico Mensal", "Nenhum dado encontrado.")
@@ -332,7 +393,9 @@ class EtiquetaApp(QWidget):
             texto += f"Mês: {mes}   —   Total: {total}\n"
         QMessageBox.information(self, "Histórico Mensal", texto)
 
-    def _atualizar_contagem_label(self):
+    def _atualizar_contagem_label(self) -> None:
+        """Atualiza o texto que mostra os totais de etiquetas."""
+
         nome_mes = datetime.now().strftime("%m/%Y")
         self._contagem_label.setText(
             f"Etiquetas do mês: <span style='font-weight:600'>{self.contagem_mensal}</span> &nbsp;|&nbsp; "

--- a/utils.py
+++ b/utils.py
@@ -1,32 +1,46 @@
-# utils.py
-import sys
+"""Funções utilitárias utilizadas pelo aplicativo."""
+
 import os
 import shutil
+import sys
 from datetime import datetime
+
 from PIL import Image
 
 def _base_dir() -> str:
+    """Obtém o diretório base do aplicativo.
+
+    Returns:
+        str: Caminho do diretório base.
     """
-    Diretório base do aplicativo.
-    - PyInstaller (onefile): usa a pasta temporária do _MEIPASS.
-    - Dev (.py): usa a pasta deste arquivo.
-    """
+
     if getattr(sys, "frozen", False) and hasattr(sys, "_MEIPASS"):
         return sys._MEIPASS
     return os.path.dirname(os.path.abspath(__file__))
 
 def recurso_caminho(rel_path: str) -> str:
+    """Constroi caminho absoluto para um recurso em ``assets``.
+
+    Args:
+        rel_path (str): Caminho relativo dentro de ``assets``.
+
+    Returns:
+        str: Caminho absoluto para o recurso.
     """
-    Caminho absoluto para um recurso dentro da pasta 'assets'.
-    Funciona igual em dev e no .exe (desde que você inclua --add-data "assets;assets").
-    """
+
     return os.path.join(_base_dir(), "assets", rel_path)
 
-def melhorar_logo(path_logo: str, largura_desejada: int = 160):
+def melhorar_logo(path_logo: str, largura_desejada: int = 160) -> tuple[bytes, int, int]:
+    """Converte a logo para bitmap monocromático TSPL.
+
+    Args:
+        path_logo (str): Caminho para a imagem da logo.
+        largura_desejada (int, optional): Largura final desejada. Padrão 160.
+
+    Returns:
+        tuple[bytes, int, int]: Dados do bitmap, largura em bytes e altura em pixels.
     """
-    Carrega, redimensiona e converte a logo para bitmap monocromático TSPL.
-    Retorna: (dados_do_bitmap_em_bytes, largura_em_bytes, altura_em_pixels)
-    """
+
     logo = Image.open(path_logo).convert("L")  # escala de cinza
     proporcao = largura_desejada / logo.width
     nova_altura = int(round(logo.height * proporcao))
@@ -53,10 +67,9 @@ def melhorar_logo(path_logo: str, largura_desejada: int = 160):
     # >>> importante: retornar bytes, não bytearray, para concatenar com b"..."
     return bytes(bitmap_data), largura_em_bytes, logo_bw.height
 
-def backup_automatico():
-    """
-    Copia arquivos importantes de 'assets' para uma pasta '_backup' ao lado do app.
-    """
+def backup_automatico() -> None:
+    """Realiza cópia de segurança dos arquivos de dados."""
+
     base = _base_dir()
     origem = os.path.join(base, "assets")
     destino = os.path.join(base, "_backup")
@@ -69,16 +82,20 @@ def backup_automatico():
         if os.path.exists(orig):
             nome_backup = f"{arq.replace('.', f'_{agora}.')}"
             shutil.copy2(orig, os.path.join(destino, nome_backup))
-def _install_dir():
-    # pasta do .exe quando congelado; pasta deste arquivo em dev
-    return os.path.dirname(sys.executable) if getattr(sys, "frozen", False) else os.path.dirname(os.path.abspath(__file__))
 
-def migrate_legacy_data():
-    """
-    Copia arquivos importantes de _internal (legado) para assets (novo).
-    Se já existirem em assets, não sobrescreve. Depois tenta renomear _internal para backup.
-    Pode rodar várias vezes sem problema.
-    """
+
+def _install_dir() -> str:
+    """Retorna o diretório de instalação do aplicativo."""
+
+    return (
+        os.path.dirname(sys.executable)
+        if getattr(sys, "frozen", False)
+        else os.path.dirname(os.path.abspath(__file__))
+    )
+
+def migrate_legacy_data() -> None:
+    """Migra arquivos legados para a nova estrutura de ``assets``."""
+
     base = _install_dir()
     old_dir = os.path.join(base, "_internal")
     new_dir = os.path.join(base, "assets")


### PR DESCRIPTION
## Summary
- organize imports, add type hints, and include Google-style Portuguese docstrings across modules
- clean up utilities and printing routines with clearer comments and structured error handling
- document and refactor the UI setup for readability and maintainability

## Testing
- `python -m py_compile _version.py main.py persistence.py printing.py ui.py utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68962491be14832cb732681a270479b0