### PR TITLE
Add type hints and mypy config

### DIFF
--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,2 @@
+[mypy]
+ignore_missing_imports = True

--- a/persistence.py
+++ b/persistence.py
@@ -5,6 +5,8 @@ import json
 import os
 from datetime import datetime
 
+from typing import cast
+
 from utils import recurso_caminho
 
 
@@ -17,11 +19,11 @@ def carregar_contagem() -> tuple[int, int]:
 
     caminho = recurso_caminho("contagem.json")
     mes_atual = datetime.now().strftime("%m-%Y")
-    contagem_total = 0
-    contagem_mensal = 0
+    contagem_total: int = 0
+    contagem_mensal: int = 0
     if os.path.exists(caminho):
         with open(caminho, "r", encoding="utf-8") as arquivo:
-            dados = json.load(arquivo)
+            dados: dict[str, int | str] = json.load(arquivo)
         if dados.get("mes_atual") == mes_atual:
             contagem_total = int(dados.get("total_geral") or 0)
             contagem_mensal = int(dados.get("total_mes") or 0)
@@ -44,7 +46,7 @@ def salvar_contagem(contagem_total: int, contagem_mensal: int) -> None:
 
     caminho = recurso_caminho("contagem.json")
     os.makedirs(os.path.dirname(caminho), exist_ok=True)
-    dados = {
+    dados: dict[str, int | str] = {
         "total_geral": int(contagem_total or 0),
         "total_mes": int(contagem_mensal or 0),
         "mes_atual": datetime.now().strftime("%m-%Y"),
@@ -94,7 +96,7 @@ def registrar_contagem_mensal(mes: str, quantidade: int) -> None:
     caminho = recurso_caminho("contagem_mensal.json")
     if os.path.exists(caminho):
         with open(caminho, "r", encoding="utf-8") as arquivo:
-            dados = json.load(arquivo)
+            dados: dict[str, int] = json.load(arquivo)
     else:
         dados = {}
     dados[mes] = dados.get(mes, 0) + quantidade
@@ -112,5 +114,5 @@ def carregar_historico_mensal() -> dict[str, int]:
     caminho = recurso_caminho("contagem_mensal.json")
     if os.path.exists(caminho):
         with open(caminho, "r", encoding="utf-8") as arquivo:
-            return json.load(arquivo)
+            return cast(dict[str, int], json.load(arquivo))
     return {}

--- a/printing.py
+++ b/printing.py
@@ -4,9 +4,9 @@ import win32print
 
 from utils import melhorar_logo, recurso_caminho
 
-LARGURA_ETIQUETA_MM = 60
-ALTURA_ETIQUETA_MM = 80
-DOTS_MM = 8  # ~203 dpi
+LARGURA_ETIQUETA_MM: int = 60
+ALTURA_ETIQUETA_MM: int = 80
+DOTS_MM: int = 8  # ~203 dpi
 
 
 def imprimir_etiqueta(

--- a/utils.py
+++ b/utils.py
@@ -51,13 +51,17 @@ def melhorar_logo(
     nova_altura = int(round(logo.height * proporcao))
 
     # Redimensiona com alta qualidade
-    logo = logo.resize((largura_desejada, nova_altura), resample=Image.LANCZOS)
+    logo = logo.resize(
+        (largura_desejada, nova_altura), resample=Image.Resampling.LANCZOS
+    )
 
     # Binarização/dithering
-    logo_bw = logo.convert("1", dither=Image.FLOYDSTEINBERG)
+    logo_bw = logo.convert("1", dither=Image.Dither.FLOYDSTEINBERG)
 
     largura_em_bytes = largura_desejada // 8
     pixels = logo_bw.load()
+    if pixels is None:
+        raise RuntimeError("Falha ao carregar pixels")
 
     bitmap_data = bytearray()
     for y in range(logo_bw.height):


### PR DESCRIPTION
## Summary
- add type annotations for label size constants
- improve logo bitmap conversion with typed resampling and pixel checks
- type persistent counter helpers and add mypy config

## Testing
- `mypy .`


------
https://chatgpt.com/codex/tasks/task_e_68962afcd72c832c9b764050f9319724