### PR TITLE
Add tests for printing, persistence and logo utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,16 @@
 
 ---
 
+## Testes
+
+Para executar a suíte de testes automatizados, instale as dependências e rode:
+
+```
+pytest -q
+```
+
+---
+
 ## Autor
 
 Desenvolvido por Pedro Luiz Bortot  

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -q

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,37 @@
+import json
+import csv
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import persistence
+
+def _patch_paths(monkeypatch, tmp_path):
+    monkeypatch.setattr(persistence, "recurso_caminho", lambda p: os.path.join(tmp_path, p))
+
+def test_salvar_e_carregar_contagem(monkeypatch, tmp_path):
+    _patch_paths(monkeypatch, tmp_path)
+    persistence.salvar_contagem(5, 2)
+    assert json.loads((tmp_path / "contagem.json").read_text())["total_geral"] == 5
+    total, mensal = persistence.carregar_contagem()
+    assert (total, mensal) == (5, 2)
+
+def test_carregar_contagem_reseta_mes(monkeypatch, tmp_path):
+    _patch_paths(monkeypatch, tmp_path)
+    dados = {"total_geral": 7, "total_mes": 4, "mes_atual": "01-2000"}
+    (tmp_path / "contagem.json").write_text(json.dumps(dados))
+    total, mensal = persistence.carregar_contagem()
+    assert total == 7
+    assert mensal == 0
+
+def test_salvar_historico_e_registrar(monkeypatch, tmp_path):
+    _patch_paths(monkeypatch, tmp_path)
+    persistence.salvar_historico("s", "c", "e", "m", 3, "data")
+    with open(tmp_path / "historico_impressoes.csv", newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+    assert rows[0] == ["Data e Hora", "Saída", "Categoria", "Emissor", "Município", "Volumes"]
+    assert rows[1] == ["data", "s", "c", "e", "m", "3"]
+
+    persistence.registrar_contagem_mensal("05-2024", 3)
+    assert persistence.carregar_historico_mensal() == {"05-2024": 3}

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+
+class FakeWin32:
+    def __init__(self):
+        self.written: list[bytes] = []
+
+    def GetDefaultPrinter(self):
+        return "dummy"
+
+    def OpenPrinter(self, name):
+        return object()
+
+    def StartDocPrinter(self, h, level, info):
+        pass
+
+    def StartPagePrinter(self, h):
+        pass
+
+    def WritePrinter(self, h, data):
+        self.written.append(data)
+
+    def EndPagePrinter(self, h):
+        pass
+
+    def EndDocPrinter(self, h):
+        pass
+
+    def ClosePrinter(self, h):
+        pass
+
+
+fake_win32 = FakeWin32()
+sys.modules["win32print"] = fake_win32
+
+import printing
+
+
+def test_reimpressao_faltantes(monkeypatch):
+    fake = printing.win32print
+    monkeypatch.setattr(printing, "melhorar_logo", lambda p, largura_desejada=240: (b"ABC", 1, 1))
+    monkeypatch.setattr(printing, "recurso_caminho", lambda p: "fake")
+
+    total = 10
+    faltantes = 3
+    inicio = total - faltantes + 1
+
+    printing.imprimir_etiqueta(
+        "S1",
+        "Cat",
+        "Emissor",
+        "Mun",
+        faltantes,
+        "2024-01-01",
+        0,
+        0,
+        inicio_indice=inicio,
+        total_exibicao=total,
+    )
+
+    assert len(fake.written) == faltantes
+    textos = [data.decode("latin1") for data in fake.written]
+    assert any("8 DE 10" in t for t in textos)
+    assert any("9 DE 10" in t for t in textos)
+    assert any("10 DE 10" in t for t in textos)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,18 @@
+import os
+import sys
+from PIL import Image
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+import utils
+
+
+def test_melhorar_logo_shape(tmp_path):
+    img_path = tmp_path / "logo.png"
+    Image.new("L", (8, 8), color=255).save(img_path)
+
+    bitmap, largura_bytes, altura = utils.melhorar_logo(str(img_path), largura_desejada=8)
+
+    assert largura_bytes == 1
+    assert altura == 8
+    assert len(bitmap) == largura_bytes * altura


### PR DESCRIPTION
## Summary
- Add tests for reprint index/total handling in `imprimir_etiqueta`
- Cover persistence serialization and monthly reset logic
- Verify logo processing returns expected bitmap dimensions
- Provide pytest configuration and testing instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68962d006b40832c83fdd580d68e8245