### PR TITLE
Build Windows executable via PyInstaller

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -1,0 +1,28 @@
+name: Build Windows Executable
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pyinstaller pyqt5 pillow pywin32
+      - name: Build executable
+        run: |
+          pyinstaller GeradorEtiquetas_onefile.spec
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: GeradorEtiquetas
+          path: dist/GeradorEtiquetas.exe

--- a/GeradorEtiquetas_onefile.spec
+++ b/GeradorEtiquetas_onefile.spec
@@ -1,0 +1,39 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['main.py'],
+    pathex=[],
+    binaries=[],
+    datas=[('assets', 'assets')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='GeradorEtiquetas',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=False,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+    icon=['assets\\color.ico'],
+)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,30 @@ Para executar a suíte de testes automatizados, instale as dependências e rode:
 pytest -q
 ```
 
+## Como buildar local
+
+1. Instale as dependências:
+
+   ```
+   pip install pyinstaller pyqt5 pillow pywin32
+   ```
+
+2. Gere o executável:
+
+   ```
+   pyinstaller GeradorEtiquetas_onefile.spec
+   ```
+
+   O binário será criado em `dist/GeradorEtiquetas.exe`.
+
+## Como baixar o artifact
+
+Após um push ou pull request, o workflow **Build Windows Executable** gera um artifact com o executável.
+
+1. Acesse a aba **Actions** do repositório no GitHub.
+2. Abra a execução mais recente do workflow.
+3. Baixe o artifact **GeradorEtiquetas** para obter `GeradorEtiquetas.exe`.
+
 ---
 
 ## Autor


### PR DESCRIPTION
## Summary
- add PyInstaller spec for onefile Windows executable
- create GitHub Actions workflow to build and publish Windows artifact
- document building locally and downloading workflow artifact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689631fbe720832cabe2f32d00ea3660