### PR TITLE
chore: add linting and formatting

### DIFF
--- a/persistence.py
+++ b/persistence.py
@@ -4,7 +4,6 @@ import csv
 import json
 import os
 from datetime import datetime
-
 from typing import cast
 
 from utils import recurso_caminho

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,10 @@
 line-length = 88
 target-version = ['py311']
 
+[tool.isort]
+profile = "black"
+line_length = 88
+
 [tool.ruff]
 line-length = 88
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 PyQt5>=5.15.0
 Pillow>=10.0.0
 pywin32>=306
+black
+isort
+ruff

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,36 +1,56 @@
-import json
 import csv
+import json
 import os
 import sys
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
 
-import persistence
 
 def _patch_paths(monkeypatch, tmp_path):
-    monkeypatch.setattr(persistence, "recurso_caminho", lambda p: os.path.join(tmp_path, p))
+    import persistence
+
+    monkeypatch.setattr(
+        persistence,
+        "recurso_caminho",
+        lambda p: os.path.join(tmp_path, p),
+    )
+    return persistence
+
 
 def test_salvar_e_carregar_contagem(monkeypatch, tmp_path):
-    _patch_paths(monkeypatch, tmp_path)
+    persistence = _patch_paths(monkeypatch, tmp_path)
     persistence.salvar_contagem(5, 2)
     assert json.loads((tmp_path / "contagem.json").read_text())["total_geral"] == 5
     total, mensal = persistence.carregar_contagem()
     assert (total, mensal) == (5, 2)
 
+
 def test_carregar_contagem_reseta_mes(monkeypatch, tmp_path):
-    _patch_paths(monkeypatch, tmp_path)
+    persistence = _patch_paths(monkeypatch, tmp_path)
     dados = {"total_geral": 7, "total_mes": 4, "mes_atual": "01-2000"}
     (tmp_path / "contagem.json").write_text(json.dumps(dados))
     total, mensal = persistence.carregar_contagem()
     assert total == 7
     assert mensal == 0
 
+
 def test_salvar_historico_e_registrar(monkeypatch, tmp_path):
-    _patch_paths(monkeypatch, tmp_path)
+    persistence = _patch_paths(monkeypatch, tmp_path)
     persistence.salvar_historico("s", "c", "e", "m", 3, "data")
-    with open(tmp_path / "historico_impressoes.csv", newline="", encoding="utf-8-sig") as f:
+    with open(
+        tmp_path / "historico_impressoes.csv",
+        newline="",
+        encoding="utf-8-sig",
+    ) as f:
         rows = list(csv.reader(f, delimiter=";"))
-    assert rows[0] == ["Data e Hora", "Saída", "Categoria", "Emissor", "Município", "Volumes"]
+    assert rows[0] == [
+        "Data e Hora",
+        "Saída",
+        "Categoria",
+        "Emissor",
+        "Município",
+        "Volumes",
+    ]
     assert rows[1] == ["data", "s", "c", "e", "m", "3"]
 
     persistence.registrar_contagem_mensal("05-2024", 3)

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -36,12 +36,16 @@ class FakeWin32:
 fake_win32 = FakeWin32()
 sys.modules["win32print"] = fake_win32
 
-import printing
-
 
 def test_reimpressao_faltantes(monkeypatch):
+    import printing
+
     fake = printing.win32print
-    monkeypatch.setattr(printing, "melhorar_logo", lambda p, largura_desejada=240: (b"ABC", 1, 1))
+    monkeypatch.setattr(
+        printing,
+        "melhorar_logo",
+        lambda p, largura_desejada=240: (b"ABC", 1, 1),
+    )
     monkeypatch.setattr(printing, "recurso_caminho", lambda p: "fake")
 
     total = 10

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,6 @@
 import os
 import sys
+
 from PIL import Image
 
 sys.path.append(os.path.dirname(os.path.dirname(__file__)))
@@ -11,7 +12,9 @@ def test_melhorar_logo_shape(tmp_path):
     img_path = tmp_path / "logo.png"
     Image.new("L", (8, 8), color=255).save(img_path)
 
-    bitmap, largura_bytes, altura = utils.melhorar_logo(str(img_path), largura_desejada=8)
+    bitmap, largura_bytes, altura = utils.melhorar_logo(
+        str(img_path), largura_desejada=8
+    )
 
     assert largura_bytes == 1
     assert altura == 8


### PR DESCRIPTION
## Summary
- configure project formatting with Black, Ruff and isort
- add linting tools to requirements
- normalize imports and line lengths to satisfy new linters

## Testing
- `black .`
- `ruff check .`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68963c77d19c832c97baadf4b06e742d