### PR TITLE
feat: build Windows exe via PyInstaller

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,7 +20,7 @@ jobs:
           pip install pyinstaller pyqt5 pillow pywin32
       - name: Build executable
         run: |
-          pyinstaller GeradorEtiquetas_onefile.spec
+          pyinstaller main.py --onefile --windowed --icon assets/color.ico --add-data "assets;assets"
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ pytest -q
 
 ## Como baixar o artifact
 
-Após um push ou pull request, o workflow **Build Windows Executable** gera um artifact com o executável.
+Após cada push ou pull request, o workflow **Build Windows Executable** compila o aplicativo e disponibiliza `GeradorEtiquetas.exe` como artifact.
 
 1. Acesse a aba **Actions** do repositório no GitHub.
 2. Abra a execução mais recente do workflow.
-3. Baixe o artifact **GeradorEtiquetas** para obter `GeradorEtiquetas.exe`.
+3. Baixe o artifact **GeradorEtiquetas** para obter `dist/GeradorEtiquetas.exe`.
 
 ## Atualização do aplicativo
 


### PR DESCRIPTION
## Summary
- build Windows executable with PyInstaller using onefile/windowed/icon/assets options
- document how to download workflow artifact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896433cb638832ca06877d4f4b99d22