### PR TITLE
Gracefully handle missing printers

### DIFF
--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -37,6 +37,12 @@ fake_win32 = FakeWin32()
 sys.modules["win32print"] = fake_win32  # type: ignore[assignment]
 
 
+def test_descobrir_impressora_padrao():
+    import printing
+
+    assert printing.descobrir_impressora_padrao() == "dummy"
+
+
 def test_reimpressao_faltantes(monkeypatch):
     import printing
 


### PR DESCRIPTION
## Summary
- Add `descobrir_impressora_padrao` helper and return detailed win32 errors
- Disable print when no printer and offer a **Testar conexão** button
- Update tests for printer detection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6896484ceb04832ca07b56ba6c3c7b09