### PR TITLE
feat: add printable templates

### DIFF
--- a/assets/templates.json
+++ b/assets/templates.json
@@ -1,0 +1,12 @@
+{
+  "Padrão": {
+    "largura_mm": 60,
+    "altura_mm": 80,
+    "gap_mm": 2
+  },
+  "Compacto": {
+    "largura_mm": 50,
+    "altura_mm": 60,
+    "gap_mm": 2
+  }
+}

--- a/printing.py
+++ b/printing.py
@@ -2,15 +2,50 @@
 
 from typing import TypedDict
 
+import json
 import time
 import win32print
 
 from utils import melhorar_logo, recurso_caminho
 from log import logger
 
+DOTS_MM: int = 8  # ~203 dpi
+
+# -------------------- templates --------------------
+try:
+    with open(recurso_caminho("templates.json"), "r", encoding="utf-8") as f:
+        TEMPLATES: dict[str, dict[str, int]] = json.load(f)
+except Exception:
+    # Fallback para garantir funcionamento mesmo sem arquivo
+    TEMPLATES = {
+        "Padrão": {"largura_mm": 60, "altura_mm": 80, "gap_mm": 2}
+    }
+
 LARGURA_ETIQUETA_MM: int = 60
 ALTURA_ETIQUETA_MM: int = 80
-DOTS_MM: int = 8  # ~203 dpi
+GAP_MM: int = 2
+
+
+def listar_templates() -> list[str]:
+    """Retorna a lista de nomes de templates disponíveis."""
+
+    return list(TEMPLATES.keys())
+
+
+def aplicar_template(nome: str) -> None:
+    """Define qual template será utilizado nas impressões."""
+
+    modelo = TEMPLATES.get(nome)
+    if not modelo:
+        modelo = TEMPLATES[list(TEMPLATES.keys())[0]]
+    global LARGURA_ETIQUETA_MM, ALTURA_ETIQUETA_MM, GAP_MM
+    LARGURA_ETIQUETA_MM = int(modelo.get("largura_mm", 60))
+    ALTURA_ETIQUETA_MM = int(modelo.get("altura_mm", 80))
+    GAP_MM = int(modelo.get("gap_mm", 2))
+
+
+# aplica template padrão ao importar módulo
+aplicar_template("Padrão")
 
 
 class ErroImpressora(TypedDict):
@@ -78,7 +113,7 @@ def imprimir_etiqueta(
                 numero_atual = inicio_indice + offset  # ex.: 7,8,9,10
                 cmd = (
                     f"SIZE {LARGURA_ETIQUETA_MM} mm,{ALTURA_ETIQUETA_MM} mm\n"
-                    "GAP 2 mm,0 mm\n"
+                    f"GAP {GAP_MM} mm,0 mm\n"
                     "CLS\n"
                     'TEXT 30,  20,"3",0,2,2,"CONIMS"\n'
                     'TEXT 30,  70,"2",0,1,1,"Saida: {saida}"\n'
@@ -153,7 +188,7 @@ def imprimir_pagina_teste(
             # --- monta pagina de teste ---
             cmd = (
                 f"SIZE {LARGURA_ETIQUETA_MM} mm,{ALTURA_ETIQUETA_MM} mm\n"
-                "GAP 2 mm,0 mm\n"
+                f"GAP {GAP_MM} mm,0 mm\n"
                 "CLS\n"
                 'TEXT 30,  20,"3",0,2,2,"CONIMS"\n'
                 'TEXT 30,  70,"2",0,1,1,"Saída: 000"\n'

--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -97,6 +97,22 @@ def test_imprimir_pagina_teste(monkeypatch):
     assert "BAR 30,600,400,4" in texto
 
 
+def test_templates_alteram_layout(monkeypatch):
+    import printing
+
+    fake_win32.written.clear()
+    monkeypatch.setattr(
+        printing, "melhorar_logo", lambda p, largura_desejada=240: (b"A", 1, 1)
+    )
+    monkeypatch.setattr(printing, "recurso_caminho", lambda p: "fake")
+
+    printing.aplicar_template("Compacto")
+    printing.imprimir_etiqueta("S", "C", "E", "M", 1, "2024-01-01")
+    texto = fake_win32.written[-1].decode("latin1")
+    assert "SIZE 50 mm,60 mm" in texto
+    printing.aplicar_template("Padrão")
+
+
 def test_retry_exponencial_logging(monkeypatch, caplog):
     import printing
     import logging

--- a/ui.py
+++ b/ui.py
@@ -43,6 +43,8 @@ from printing import (
     imprimir_etiqueta,
     descobrir_impressora_padrao,
     imprimir_pagina_teste,
+    listar_templates,
+    aplicar_template,
 )
 from utils import backup_automatico, recurso_caminho
 from log import logger, LOG_FILE
@@ -167,6 +169,10 @@ class EtiquetaApp(QWidget):
         self.municipio_input.setEditable(True)
         self.volumes_input = QSpinBox()
         self.volumes_input.setMinimum(1)
+        self.template_input = QComboBox()
+        self.template_input.addItems(listar_templates())
+        self.template_input.currentTextChanged.connect(aplicar_template)
+        aplicar_template(self.template_input.currentText())
         self._carregar_listas()
 
         def _estilo(w):
@@ -181,6 +187,7 @@ class EtiquetaApp(QWidget):
             self.emissor_input,
             self.municipio_input,
             self.volumes_input,
+            self.template_input,
         ):
             _estilo(w)
 
@@ -201,6 +208,8 @@ class EtiquetaApp(QWidget):
         grid.addWidget(self.municipio_input, 3, 1)
         grid.addWidget(_lbl("Número de Volumes:"), 4, 0)
         grid.addWidget(self.volumes_input, 4, 1)
+        grid.addWidget(_lbl("Modelo:"), 5, 0)
+        grid.addWidget(self.template_input, 5, 1)
 
         self.retry_checkbox = QCheckBox("Repetir automaticamente em falha (3x)")
         self.retry_checkbox.setStyleSheet(


### PR DESCRIPTION
## Summary
- load label templates from `assets/templates.json`
- add template selection combo to UI
- apply template dimensions during printing

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68965576d02c832cb045a69569d54c9b