### PR TITLE
feat: gerar relatório mensal consolidado

### DIFF
--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -55,3 +55,26 @@ def test_salvar_historico_e_registrar(monkeypatch, tmp_path):
 
     persistence.registrar_contagem_mensal("05-2024", 3)
     assert persistence.carregar_historico_mensal() == {"05-2024": 3}
+
+
+def test_gerar_relatorio_mensal(monkeypatch, tmp_path):
+    persistence = _patch_paths(monkeypatch, tmp_path)
+    with open(
+        tmp_path / "historico_impressoes.csv",
+        "w",
+        newline="",
+        encoding="utf-8-sig",
+    ) as f:
+        f.write("Data e Hora;Saída;Categoria;Emissor;Município;Volumes\n")
+        f.write("06/08/2025 09:30:13;1;Cat;Emi;Mun;1\n")
+        f.write("07/08/2025 10:00:00;2;Cat;Emi;Mun;2\n")
+        f.write("01/09/2025 00:00:00;3;Cat2;Emi2;Mun2;3\n")
+
+    path = persistence.gerar_relatorio_mensal("2025-08")
+    assert (tmp_path / "reports" / "relatorio_2025-08.csv").exists()
+    with open(path, newline="", encoding="utf-8-sig") as f:
+        rows = list(csv.reader(f, delimiter=";"))
+    assert rows == [
+        ["Categoria", "Município", "Emissor", "Volumes"],
+        ["Cat", "Mun", "Emi", "3"],
+    ]

--- a/ui.py
+++ b/ui.py
@@ -35,6 +35,7 @@ from PyQt5.QtWidgets import (
 from persistence import (
     carregar_contagem,
     carregar_historico_mensal,
+    gerar_relatorio_mensal,
     registrar_contagem_mensal,
     salvar_contagem,
     salvar_historico,
@@ -234,6 +235,13 @@ class EtiquetaApp(QWidget):
         self.historico_mes_btn = QPushButton("Histórico Mensal")
         self.historico_mes_btn.clicked.connect(self._mostrar_historico_mensal)
 
+        self.exportar_relatorio_btn = QPushButton(
+            "Exportar relatório do mês atual"
+        )
+        self.exportar_relatorio_btn.clicked.connect(
+            self._exportar_relatorio_mes_atual
+        )
+
         self.log_btn = QPushButton("Ver Log")
         self.log_btn.clicked.connect(self._abrir_log)
 
@@ -249,6 +257,7 @@ class EtiquetaApp(QWidget):
             self.reimprimir_faltantes_btn,
             self.historico_btn,
             self.historico_mes_btn,
+            self.exportar_relatorio_btn,
             self.log_btn,
             self.teste_pagina_btn,
             self.testar_conexao_btn,
@@ -608,6 +617,27 @@ class EtiquetaApp(QWidget):
         for mes, total in sorted(hist.items()):
             texto += f"Mês: {mes}   —   Total: {total}\n"
         QMessageBox.information(self, "Histórico Mensal", texto)
+
+    def _exportar_relatorio_mes_atual(self) -> None:
+        """Exporta o relatório consolidado do mês atual."""
+
+        mes = datetime.now().strftime("%Y-%m")
+        try:
+            caminho = gerar_relatorio_mensal(mes)
+            QMessageBox.information(
+                self,
+                "Relatório Mensal",
+                f"Relatório salvo em:\n{caminho}",
+            )
+        except FileNotFoundError:
+            QMessageBox.information(
+                self,
+                "Relatório Mensal",
+                "Histórico de impressões não encontrado.",
+            )
+        except Exception as e:
+            logger.exception("Erro ao gerar relatório mensal")
+            QMessageBox.critical(self, "Erro", str(e))
 
     def _atualizar_contagem_label(self) -> None:
         """Atualiza o texto que mostra os totais de etiquetas."""


### PR DESCRIPTION
## Summary
- add monthly report generator that aggregates historical prints and exports CSV
- expose button to export current month report via UI
- test report generation for expected aggregation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899d01e477c832cb68387211c605027