### PR TITLE
Persist recent selection history

### DIFF
--- a/assets/recentes.json
+++ b/assets/recentes.json
@@ -1,0 +1,5 @@
+{
+  "categoria": {},
+  "emissor": {},
+  "municipio": {}
+}

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -78,3 +78,17 @@ def test_gerar_relatorio_mensal(monkeypatch, tmp_path):
         ["Categoria", "Município", "Emissor", "Volumes"],
         ["Cat", "Mun", "Emi", "3"],
     ]
+
+
+def test_atualizar_recentes(monkeypatch, tmp_path):
+    persistence = _patch_paths(monkeypatch, tmp_path)
+    persistence.atualizar_recentes("cat1", "emi1", "mun1")
+    persistence.atualizar_recentes("cat1", "emi2", "mun2")
+    dados = persistence.carregar_recentes()
+    assert dados["categoria"]["cat1"] == 2
+    listas = persistence.carregar_recentes_listas()
+    assert listas["categoria"][0] == "cat1"
+    for i in range(25):
+        persistence.atualizar_recentes(f"c{i}", f"e{i}", f"m{i}")
+    dados = persistence.carregar_recentes()
+    assert len(dados["categoria"]) == 20


### PR DESCRIPTION
## Summary
- store most-used categorias, emissores e municípios in assets/recentes.json
- preload combos with recent items before defaults and update after printing
- test persistence of recent selections

## Testing
- `isort persistence.py ui.py tests/test_persistence.py`
- `black persistence.py ui.py tests/test_persistence.py`
- `ruff check persistence.py ui.py tests/test_persistence.py --fix`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6899ef427038832caf5351ecebf8a1eb