### PR TITLE
Sanitize form inputs and add validations

### DIFF
--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,24 @@
+import os
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from utils import normalize_text
+
+
+def test_normalize_text_trim_and_ok():
+    text, err = normalize_text("  abc  ", max_len=10)
+    assert text == "abc"
+    assert err is None
+
+
+def test_normalize_text_removes_semicolon():
+    text, err = normalize_text("ab;c", max_len=10)
+    assert text == "abc"
+    assert err is not None
+
+
+def test_normalize_text_truncate_and_error():
+    text, err = normalize_text("x" * 12, max_len=10)
+    assert text == "x" * 10
+    assert err is not None

--- a/utils.py
+++ b/utils.py
@@ -33,6 +33,26 @@ def recurso_caminho(rel_path: str) -> str:
     return os.path.join(_base_dir(), "assets", rel_path)
 
 
+def normalize_text(texto: str, *, max_len: int) -> tuple[str, str | None]:
+    """Remove espaços extras e caracteres inválidos de ``texto``.
+
+    Args:
+        texto (str): Texto de entrada.
+        max_len (int): Tamanho máximo permitido.
+
+    Returns:
+        tuple[str, str | None]: Texto normalizado e mensagem de erro, se houver.
+    """
+
+    limpo = texto.strip()
+    if ";" in limpo:
+        limpo = limpo.replace(";", "")
+        return limpo[:max_len], "Caracter ';' removido"
+    if len(limpo) > max_len:
+        return limpo[:max_len], f"Limite de {max_len} caracteres excedido"
+    return limpo, None
+
+
 def melhorar_logo(
     path_logo: str, largura_desejada: int = 160
 ) -> tuple[bytes, int, int]:
@@ -161,7 +181,9 @@ def migrate_legacy_data() -> None:
                 dst_lines,
             )
 
-            if os.path.exists(destino) and (dst_size > src_size or dst_lines > src_lines):
+            if os.path.exists(destino) and (
+                dst_size > src_size or dst_lines > src_lines
+            ):
                 logger.info(
                     "%s existente é maior; arquivo legado mantido como backup", nome
                 )


### PR DESCRIPTION
## Summary
- normalize text fields and enforce character limits
- block invalid ';' characters and show tooltip errors
- add tests for input normalization

## Testing
- `pytest`
- `ruff check ui.py utils.py tests/test_normalize.py`


------
https://chatgpt.com/codex/tasks/task_e_689a1aeb58c8832cbb6ae3df837426d4