### PR TITLE
Add layout mapping and panoramic label support

### DIFF
--- a/tests/test_printing.py
+++ b/tests/test_printing.py
@@ -149,6 +149,24 @@ def test_templates_alteram_layout(monkeypatch):
     printing.aplicar_template("Padrão")
 
 
+def test_panoramico_layout(monkeypatch):
+    import printing
+
+    fake_win32.written.clear()
+    monkeypatch.setattr(
+        printing, "melhorar_logo", lambda p, largura_desejada=240: (b"A", 1, 1)
+    )
+    monkeypatch.setattr(printing, "recurso_caminho", lambda p: "fake")
+
+    printing.aplicar_template("Panoramico")
+    printing.imprimir_etiqueta("S", "C", "E", "M", 1, "2024-01-01")
+    texto = fake_win32.written[-1].decode("latin1")
+    assert "SIZE 100 mm,30 mm" in texto
+    spec = printing.LAYOUTS["Panoramico"]["numeracao"]
+    assert f'TEXT {spec["x"]},{spec["y"]}' in texto
+    printing.aplicar_template("Padrão")
+
+
 def test_retry_exponencial_logging(monkeypatch, caplog):
     import printing
     import logging


### PR DESCRIPTION
## Summary
- introduce `LAYOUTS` mapping for label coordinates and fonts, including new panoramic 100x30 layout
- refactor `imprimir_etiqueta` to fetch positions from current layout
- ensure `aplicar_template` switches label layout and add tests for panoramic template

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f3fa61084832c8edebe23d28c9eee